### PR TITLE
Add thermal conductance quantity and units

### DIFF
--- a/packages/dim-isq/quantities.spec.ts
+++ b/packages/dim-isq/quantities.spec.ts
@@ -57,6 +57,9 @@ export default defineQuantitySpec({
       // Radiation and other
       absorbedDose: { L: 2, T: -2 },
       catalyticActivity: { N: 1, T: -1 },
+
+      // Thermal
+      thermalConductance: { M: 1, L: 2, T: -3, "Θ": -1 },
     },
   },
 });

--- a/packages/dim-isq/src/mod.ts
+++ b/packages/dim-isq/src/mod.ts
@@ -73,6 +73,8 @@ export {
   type Scalar,
   type Temperature,
   temperature,
+  type ThermalConductance,
+  thermalConductance,
   type Time,
   time,
   type Velocity,

--- a/packages/dim-isq/src/quantities.generated.ts
+++ b/packages/dim-isq/src/quantities.generated.ts
@@ -200,3 +200,8 @@ export const absorbedDose: QuantityFactory<AbsorbedDose> = isq.factory({
 export type CatalyticActivity = D<{ T: -1; N: 1 }>;
 export const catalyticActivity: QuantityFactory<CatalyticActivity> = isq
   .factory({ T: -1, N: 1 });
+
+/** ThermalConductance (L²·M·T⁻³·Θ⁻¹) */
+export type ThermalConductance = D<{ L: 2; M: 1; T: -3; Θ: -1 }>;
+export const thermalConductance: QuantityFactory<ThermalConductance> = isq
+  .factory({ L: 2, M: 1, T: -3, Θ: -1 });

--- a/packages/dim-si/deno.json
+++ b/packages/dim-si/deno.json
@@ -39,7 +39,8 @@
     "./luminous-flux": "./src/luminous-flux.ts",
     "./illuminance": "./src/illuminance.ts",
     "./absorbed-dose": "./src/absorbed-dose.ts",
-    "./catalytic-activity": "./src/catalytic-activity.ts"
+    "./catalytic-activity": "./src/catalytic-activity.ts",
+    "./thermal-conductance": "./src/thermal-conductance.ts"
   },
   "version": "0.2.0"
 }

--- a/packages/dim-si/src/thermal-conductance.ts
+++ b/packages/dim-si/src/thermal-conductance.ts
@@ -1,0 +1,35 @@
+/**
+ * Thermal conductance units (M·L²·T⁻³·Θ⁻¹).
+ *
+ * SI unit: watt per kelvin (W/K).
+ *
+ * @example Creating a thermal conductance
+ * ```ts
+ * import { wattPerKelvin } from "@isentropic/dim-si/thermal-conductance";
+ *
+ * const conductance = wattPerKelvin(0.5);
+ * ```
+ *
+ * @module
+ */
+
+import type { ThermalConductance } from "@isentropic/dim-isq";
+import { thermalConductance } from "@isentropic/dim-isq";
+import type { BaseUnit, ScaledUnit } from "./types.ts";
+import { si } from "./system.ts";
+import { KILO, MILLI } from "./prefixes.ts";
+
+export type { ThermalConductance } from "@isentropic/dim-isq";
+
+/** Watt per kelvin (W/K) — SI unit of thermal conductance. */
+export const wattPerKelvin: BaseUnit<ThermalConductance> = si.unit(
+  thermalConductance,
+);
+
+/** Milliwatt per kelvin (mW/K) — 10⁻³ watts per kelvin. */
+export const milliwattPerKelvin: ScaledUnit<ThermalConductance> = wattPerKelvin
+  .scaled(MILLI);
+
+/** Kilowatt per kelvin (kW/K) — 1000 watts per kelvin. */
+export const kilowattPerKelvin: ScaledUnit<ThermalConductance> = wattPerKelvin
+  .scaled(KILO);


### PR DESCRIPTION
Adds `ThermalConductance` (M·L²·T⁻³·Θ⁻¹) as a derived ISQ quantity with SI units: `wattPerKelvin`, `milliwattPerKelvin`, and `kilowattPerKelvin`.